### PR TITLE
Updated to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     default: 1
 
 runs:
-  using: node16
+  using: node20
   main: clean.js
   post: restore.js
 


### PR DESCRIPTION
I've noticed a warning at https://github.com/python-pillow/Pillow/actions/runs/7645349515
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: egor-tensin/cleanup-path@v3, codecov/codecov-action@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

So this PR updates to Node 20